### PR TITLE
Fix failures if missing coverage files or package not built

### DIFF
--- a/colcon_coveragepy_result/task/coveragepy.py
+++ b/colcon_coveragepy_result/task/coveragepy.py
@@ -31,11 +31,11 @@ class CoveragePyTask(TaskExtensionPoint):
         pkg_build_path = Path(os.path.abspath(os.path.join(args.build_base, pkg.name)))
         if not pkg_build_path.exists():
             logger.info(
-                'Skipping package {pkg.name} since it has not been built'.format_map(locals())
+                "Skipping package '{pkg.name}' since it has not been built".format_map(locals())
             )
             return 0
 
-        logger.info('Running coverage.py on {pkg.name}'.format_map(locals()))
+        logger.info("Running coveragepy task on package '{pkg.name}'".format_map(locals()))
 
         # Get list of .coverage files, depending on package type
         coverage_files = []
@@ -48,10 +48,13 @@ class CoveragePyTask(TaskExtensionPoint):
         coverage_files = list(filter(os.path.exists, coverage_files))
         if 0 == len(coverage_files):
             logger.warning(
-                'No .coverage files for package {pkg.name} of type {pkg.type}'.format_map(locals())
+                "No .coverage files found for package '{pkg.name}' of type '{pkg.type}'"
+                .format_map(locals())
             )
             return 0
-        logger.info('Coverage files for package {pkg.name}: {coverage_files}'.format_map(locals()))
+        logger.info(
+            "Coverage files for package '{pkg.name}': {coverage_files}".format_map(locals())
+        )
 
         # Copy .coverage files to a new directory, because combining files deletes them
         coveragepy_dir = self.get_package_combine_dir(args.build_base, pkg.name)

--- a/colcon_coveragepy_result/verb/coveragepy_result.py
+++ b/colcon_coveragepy_result/verb/coveragepy_result.py
@@ -100,6 +100,9 @@ class CoveragePyResultVerb(VerbExtensionPoint):
         ]
         # Filter out non-existing files in case processing failed for some packages
         coverage_files = list(filter(os.path.exists, coverage_files))
+        if 0 == len(coverage_files):
+            logger.warning('No coverage files found')
+            return 0
         logger.info('Coverage files: {coverage_files}'.format_map(locals()))
 
         # Combine .coverage files

--- a/colcon_coveragepy_result/verb/coveragepy_result.py
+++ b/colcon_coveragepy_result/verb/coveragepy_result.py
@@ -139,7 +139,7 @@ class CoveragePyResultVerb(VerbExtensionPoint):
                 coveragepy_pkgs.append(pkg)
             else:
                 logger.info(
-                    'Specified package {pkg.name} is not a coverage.py-compatible '
+                    "Specified package '{pkg.name}' is not a coverage.py-compatible "
                     'package. Not collecting coverage information.'.format_map(locals())
                 )
         return coveragepy_pkgs


### PR DESCRIPTION
This adds checks for:

* if package has been built
* has `.coverage` files (in case it is built but has no coverage files)

Closes #2